### PR TITLE
fix: provider conflict with terraform-gcp-memstore

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,18 +2,18 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0 # Get the latest version from: https://github.com/pre-commit/pre-commit-hooks/releases
+    rev: v4.3.0 # Get the latest version from: https://github.com/pre-commit/pre-commit-hooks/releases
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-yaml
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
-  - repo: git://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.64.0 # Get the latest version from: https://github.com/antonbabenko/pre-commit-terraform/releases
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.73.0 # Get the latest version from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
       - id: terraform_fmt
       - id: terraform_docs
       - id: terraform_validate
       - id: terraform_tfsec
-      - id: checkov
+      - id: terraform_checkov

--- a/modules/gcp_gcs_bucket/README.md
+++ b/modules/gcp_gcs_bucket/README.md
@@ -1,0 +1,56 @@
+# GCP GCS module
+
+This module will create bucket in GCP with enable server-side encryption and logging by default
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 4.13.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.1.2 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.7.2 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.13.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.2 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.7.2 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [google_kms_crypto_key.google_kms_crypto_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key) | resource |
+| [google_kms_crypto_key_iam_binding.google_kms_crypto_key_iam_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_binding) | resource |
+| [google_kms_key_ring.google_kms_key_ring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring) | resource |
+| [google_storage_bucket.google_storage_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket.google_storage_bucket_logging](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [random_id.random_id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [time_sleep.time_sleep](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| [google_storage_project_service_account.google_storage_project_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/storage_project_service_account) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_default_event_based_hold"></a> [default\_event\_based\_hold](#input\_default\_event\_based\_hold) | (Optional) Whether or not to automatically apply an eventBasedHold to new objects added to the bucket. | `bool` | `false` | no |
+| <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | When deleting a bucket, this boolean option will delete all contained objects. If you try to delete a bucket that contains objects, Terraform will fail that run. | `bool` | `false` | no |
+| <a name="input_location"></a> [location](#input\_location) | (Required) The GCS location | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the bucket. | `string` | n/a | yes |
+| <a name="input_storage_class"></a> [storage\_class](#input\_storage\_class) | (Optional, Default: 'STANDARD') The Storage Class of the new bucket. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE. | `string` | `"STANDARD"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_customer_managed_key_id"></a> [customer\_managed\_key\_id](#output\_customer\_managed\_key\_id) | n/a |
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_name"></a> [name](#output\_name) | n/a |
+<!-- END_TF_DOCS -->

--- a/modules/gcp_gcs_bucket/main.tf
+++ b/modules/gcp_gcs_bucket/main.tf
@@ -2,15 +2,15 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 4.13.0"
+      version = ">= 4.13.0"
     }
     time = {
       source  = "hashicorp/time"
-      version = "~> 0.7.2"
+      version = ">= 0.7.2"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 3.1.2"
+      version = ">= 3.1.2"
     }
   }
 }


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

Please confirm that you have done the following before requesting reviews:

- [ ] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [ ] I have typed an adequate description that explains **why** I am making this change.
- [ ] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

* provider conflict with terraform-gcp-memstore (terraform-gcp-memstore require at least 4.16.0 - https://github.com/honestbank/terraform-gcp-memstore/pull/6)