### PR TITLE
ci(release): Fix workflow permissions

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,2 +1,0 @@
-# Always validate the PR title, and ignore the commits
-titleOnly: true

--- a/.github/workflows/terratest.yml
+++ b/.github/workflows/terratest.yml
@@ -1,5 +1,7 @@
 name: terratest
-permissions: read-all
+permissions:
+  contents: write
+  pull-requests: write
 
 on:
   pull_request:
@@ -40,8 +42,7 @@ jobs:
         run: |
           make test_and_cover
       - name: Release
-        if: github.event_name == 'push'
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,14 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0 # Get the latest version from: https://github.com/pre-commit/pre-commit-hooks/releases
+    rev: v4.4.0 # Get the latest version from: https://github.com/pre-commit/pre-commit-hooks/releases
     hooks:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.74.1 # Get the latest version from: https://github.com/antonbabenko/pre-commit-terraform/releases
+    rev: v1.77.1 # Get the latest version from: https://github.com/antonbabenko/pre-commit-terraform/releases
     hooks:
       - id: terraform_fmt
       - id: terraform_docs

--- a/modules/gcp_gcs_bucket/README.md
+++ b/modules/gcp_gcs_bucket/README.md
@@ -15,9 +15,9 @@ This module will create bucket in GCP with enable server-side encryption and log
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | 4.54.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.4.3 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.9.1 |
+| <a name="provider_google"></a> [google](#provider\_google) | >= 4.51.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.1.2 |
+| <a name="provider_time"></a> [time](#provider\_time) | >= 0.7.2 |
 
 ## Modules
 


### PR DESCRIPTION
<!--
# Pull Request Instructions

* All PRs should reference an issue in our issue tracker. If one doesn't exist, please create one!
* PR titles should follow https://www.conventionalcommits.org.

-->

## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

The `terratest` workflow contains the `release` step (Semantic Release) which was
broken because `permissions: read-all` were applied to the workflow. This PR
sets the correct permissions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gcs/14)
<!-- Reviewable:end -->
