### PR TITLE
feat: add 30 day soft-delete policy to all GCS buckets (SEC-47)

### DIFF
--- a/examples/bucket/main.tf
+++ b/examples/bucket/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.22.0, < 6.0"
+      version = "~> 5.22"
     }
     random = {
       source  = "hashicorp/random"

--- a/examples/bucket/main.tf
+++ b/examples/bucket/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 5.0"
+      version = ">= 5.22.0, < 6.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/modules/gcp_gcs_bucket/inputs.tf
+++ b/modules/gcp_gcs_bucket/inputs.tf
@@ -56,8 +56,8 @@ variable "lifecycle_rules" {
   default     = []
 }
 
-variable "soft_delete_policy" {
+variable "soft_delete_retention_duration_seconds" {
   type        = number
-  description = "(Optional, Computed) The bucket's soft delete policy, which defines the period of time that soft-deleted objects will be retained, and cannot be permanently deleted. If the block is not provided, Server side value will be kept which means removal of block won't generate any terraform change."
+  description = "The duration in seconds that soft-deleted objects in the bucket will be retained and cannot be permanently deleted. Default value is 2678400 (30 days). The value must be in between 604800(7 days) and 7776000(90 days). Note: To disable the soft delete policy on a bucket, This field must be set to 0."
   default     = 2678400
 }

--- a/modules/gcp_gcs_bucket/inputs.tf
+++ b/modules/gcp_gcs_bucket/inputs.tf
@@ -55,3 +55,9 @@ variable "lifecycle_rules" {
   description = "List of lifecycle rules to configure. Format is the same as described in provider documentation https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule except condition.matches_storage_class should be a comma delimited string."
   default     = []
 }
+
+variable "soft_delete_policy" {
+  type        = number
+  description = "(Optional, Computed) The bucket's soft delete policy, which defines the period of time that soft-deleted objects will be retained, and cannot be permanently deleted. If the block is not provided, Server side value will be kept which means removal of block won't generate any terraform change."
+  default     = 2678400
+}

--- a/modules/gcp_gcs_bucket/main.tf
+++ b/modules/gcp_gcs_bucket/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0, < 6.0"
+      version = ">= 5.22.0, < 6.0"
     }
     time = {
       source  = "hashicorp/time"
@@ -119,5 +119,9 @@ resource "google_storage_bucket" "google_storage_bucket" {
         noncurrent_time_before     = lookup(lifecycle_rule.value.condition, "noncurrent_time_before", null)
       }
     }
+  }
+
+  soft_delete_policy {
+    retention_duration_seconds = var.soft_delete_policy
   }
 }

--- a/modules/gcp_gcs_bucket/main.tf
+++ b/modules/gcp_gcs_bucket/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 5.22.0, < 6.0"
+      version = "~> 5.22"
     }
     time = {
       source  = "hashicorp/time"
@@ -122,6 +122,6 @@ resource "google_storage_bucket" "google_storage_bucket" {
   }
 
   soft_delete_policy {
-    retention_duration_seconds = var.soft_delete_policy
+    retention_duration_seconds = var.soft_delete_retention_duration_seconds
   }
 }


### PR DESCRIPTION
## Pull Request Submission Checklist

Please confirm that you have done the following before requesting reviews:

- [x] I have confirmed that the PR type is appropriate for the change I am making according to the [Honest Pull Request and Commit Message Naming Conventions](https://www.notion.so/honestbank/Pull-Request-and-Commit-Message-Naming-Conventions-bd97f2cbb34c4c73b1ff3a3e384b850c).
- [x] I have typed an adequate description that explains **why** I am making this change.
- [x] I have installed and run standard pre-commit hooks that lints and validates my code.

### Description

This enables 30-day (2,678,400 seconds) soft delete to all GCS buckets. As this is a new feature from Google, the minimum Hashicorp Google provider needed to be bumped to v5.22.0.

This is the first part of the ransomware mitigations for GCS, allowing 30-days to detect and recover from modification/deletion of objects stored on GCS. Future work will alert on policy and mass file changes as well as prevent the deletion of project (project-liens)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/honestbank/terraform-gcp-gcs/25)
<!-- Reviewable:end -->
